### PR TITLE
Remover importacion duplicada de ViewTransitions

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,6 +1,4 @@
 ---
-import { ViewTransitions } from 'astro:transitions';
-
 import Footer from '@/components/Footer.astro';
 import Header from '@/components/Header.astro';
 
@@ -28,7 +26,6 @@ const webTitle =  title ? `Coscu Army Awards - ${title}` : "Coscu Army Awards"
 		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 		<link href="https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap" rel="stylesheet">
 		<meta name="generator" content={Astro.generator} />
-		<ViewTransitions />
 		<title>{webTitle}</title>
 		<ViewTransitions />
 	</head>


### PR DESCRIPTION
# Cambios
Imagino que hiciste merge de las dos PR para agregar ViewTransitions, pero eso genero que tuvieras una doble importacion del componente ViewTransitions.

## Capturas de Pantalla
1. Imagen 1: 
![Captura de pantalla 2024-12-16 114043](https://github.com/user-attachments/assets/8e10422b-1ead-426a-bcbd-f21d23c03563)
2. Imagen 2:
![Captura de pantalla 2024-12-16 114102](https://github.com/user-attachments/assets/1e6ee40a-ab6c-4f49-86eb-d07559420404)
