### PR TITLE
feat: add open graph

### DIFF
--- a/src/components/OpenGraph.astro
+++ b/src/components/OpenGraph.astro
@@ -1,0 +1,27 @@
+---
+interface Props {
+  title?: string
+}
+
+const { title } = Astro.props
+
+const webTitle =  title ? `Coscu Army Awards - ${title}` : "Coscu Army Awards"
+---
+
+<title>{webTitle}</title>
+<meta name="description" content="Descubre los Coscu Army Awards, la premiación más grande de streamers y creadores de contenido en Latinoamérica. Reconoce el talento de las figuras más destacadas del mundo digital.">
+
+<!-- Facebook Meta Tags -->
+<meta property="og:url" content="https://coscuarmy-awards.vercel.app">
+<meta property="og:type" content="website">
+<meta property="og:title" content="Coscu Army Awards">
+<meta property="og:description" content="Descubre los Coscu Army Awards, la premiación más grande de streamers y creadores de contenido en Latinoamérica. Reconoce el talento de las figuras más destacadas del mundo digital.">
+<meta property="og:image" content="/og-bg.webp">
+
+<!-- Twitter Meta Tags -->
+<meta name="twitter:card" content="summary_large_image">
+<meta property="twitter:domain" content="coscuarmy-awards.vercel.app">
+<meta property="twitter:url" content="https://coscuarmy-awards.vercel.app">
+<meta name="twitter:title" content="Coscu Army Awards">
+<meta name="twitter:description" content="Descubre los Coscu Army Awards, la premiación más grande de streamers y creadores de contenido en Latinoamérica. Reconoce el talento de las figuras más destacadas del mundo digital.">
+<meta name="twitter:image" content="/og-bg.webp">

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,6 +1,7 @@
 ---
 import Footer from '@/components/Footer.astro';
 import Header from '@/components/Header.astro';
+import OpenGraph from '@/components/OpenGraph.astro';
 
 import { ViewTransitions } from 'astro:transitions' 
 
@@ -10,8 +11,6 @@ interface Props {
 }
 
 const { title, bgimage } = Astro.props;
-
-const webTitle =  title ? `Coscu Army Awards - ${title}` : "Coscu Army Awards"
 ---
 
 <!doctype html>
@@ -20,13 +19,12 @@ const webTitle =  title ? `Coscu Army Awards - ${title}` : "Coscu Army Awards"
 		<meta charset="UTF-8" />
 		<meta name="viewport" content="width=device-width" />
 		<link rel="icon" type="image/x-icon" href="/favicon.ico">
-		<meta name="description" content="Descubre los Coscu Army Awards, la premiación más grande de streamers y creadores de contenido en Latinoamérica. Reconoce el talento de las figuras más destacadas del mundo digital.">
 		<link rel="preconnect" href="https://fonts.googleapis.com">
 		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 		<link href="https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap" rel="stylesheet">
 		<meta name="generator" content={Astro.generator} />
 		<ViewTransitions />
-		<title>{webTitle}</title>
+		<OpenGraph title={title} />
 	</head>
 	<body>	
 		<div


### PR DESCRIPTION
### Descripción de los cambios:

- **Agregado**: Se añadieron las etiquetas de Open Graph y Twitter para mejorar la visualización de la página en plataformas sociales. Esto incluye:
  - `og:title`: Define el título que se mostrará en las plataformas sociales.
  - `og:description`: Descripción de la página, resaltando la premiación de los Coscu Army Awards.
  - `og:image`: Se agregó una imagen de vista previa (`og-bg.webp`) para representar la página en las plataformas sociales, esta imagen es el banner de CAAwards en x, pero se puede cambiar por otra imagen .

- **Etiquetas de Twitter**: Se añadieron las etiquetas relevantes para Twitter, como `twitter:title`, `twitter:description`, y `twitter:image`, para garantizar una presentación adecuada del contenido cuando se comparta en Twitter.

